### PR TITLE
Show a correct error message on file opening failure

### DIFF
--- a/ont_fast5_api/conversion_tools/single_to_multi_fast5.py
+++ b/ont_fast5_api/conversion_tools/single_to_multi_fast5.py
@@ -34,7 +34,7 @@ def create_multi_read_file(input_files, output_file):
                         add_read_to_multi_fast5(multi_f5, single_f5)
                 except Exception as e:
                     logger.error("{}\n\tFailed to add single read file: '{}' to '{}'"
-                                 "".format(e, f, output_file), exc_info=exc_info)
+                                 "".format(e, filename, output_file), exc_info=exc_info)
     except Exception as e:
         logger.error("{}\n\tFailed to write to MultiRead file: {}"
                      "".format(e, output_file), exc_info=exc_info)


### PR DESCRIPTION
`single_to_multi_fast5` produces a less informative error message when it fails to open an input. In fact, it even stops processing a whole batch by a typo in an exception code. Please see the changes in the commit.