### PR TITLE
Select only subset of reads from multi_fast5

### DIFF
--- a/ont_fast5_api/conversion_tools/multi_to_single_fast5.py
+++ b/ont_fast5_api/conversion_tools/multi_to_single_fast5.py
@@ -28,7 +28,9 @@ class EmptyFast5(Fast5File):
 
 def batch_convert_multi_files_to_single(input_path, output_folder, readid_file, threads, recursive):
 
-    read_ids = set(l.strip() for l in readid_file)
+    read_ids = set()
+    if readid_file:
+        read_ids = set(l.strip() for l in readid_file)
     pool = Pool(threads)
     file_list = get_fast5_file_list(input_path, recursive)
     pbar = get_progress_bar(len(file_list))
@@ -70,7 +72,7 @@ def convert_multi_to_single(input_file, output_folder, read_ids, subfolder):
     try:
         with MultiFast5File(input_file, 'r') as multi_f5:
             for read_id in multi_f5.get_read_ids():
-                if read_id not in read_ids:
+                if read_ids and read_id not in read_ids:
                     continue
                 try:
                     read = multi_f5.get_read(read_id)

--- a/ont_fast5_api/conversion_tools/multi_to_single_fast5.py
+++ b/ont_fast5_api/conversion_tools/multi_to_single_fast5.py
@@ -118,7 +118,8 @@ def main():
     parser.add_argument('-v', '--version', action='version', version=__version__)
     args = parser.parse_args()
 
-    batch_convert_multi_files_to_single(args.input_path, args.save_path, args.read_ids, args.threads, args.recursive)
+    batch_convert_multi_files_to_single(args.input_path, args.save_path, args.limit_by_read_ids,
+                                        args.threads, args.recursive)
 
 
 if __name__ == '__main__':

--- a/ont_fast5_api/conversion_tools/single_to_multi_fast5.py
+++ b/ont_fast5_api/conversion_tools/single_to_multi_fast5.py
@@ -87,10 +87,14 @@ def add_read_to_multi_fast5(multi_f5, single_f5, revert=False):
     # Copy UniqueGlobalKey data into new file
     for group in single_f5.handle["UniqueGlobalKey"]:
         read.handle.copy(single_f5.handle["UniqueGlobalKey/{}".format(group)], group)
-
+        
+    if not revert:
+        # Skip any additional entries if revert
+        return
+        
     for group in single_f5.handle:
-        if group in ("Raw", "UniqueGlobalKey") or revert:
-            # Skip these as they require special handling OR if reverting to raw reads
+        if group in ("Raw", "UniqueGlobalKey"):
+            # Skip these as they require special handling
             continue
         read.handle.copy(single_f5.handle[group], group)
 

--- a/ont_fast5_api/conversion_tools/single_to_multi_fast5.py
+++ b/ont_fast5_api/conversion_tools/single_to_multi_fast5.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 exc_info = False
 
 
-def batch_convert_single_to_multi(input_path, output_folder, filename_base, batch_size, threads, recursive):
+def batch_convert_single_to_multi(input_path, output_folder, filename_base, batch_size, threads, recursive, revert):
 
     pool = Pool(threads)
     file_list = get_fast5_file_list(input_path, recursive)
@@ -114,7 +114,7 @@ def main():
     parser.add_argument('-v', '--version', action='version', version=__version__)
     args = parser.parse_args()
 
-    batch_convert_single_to_multi(args.input_path, args.save_path, args.filename_base, args.batch_size, args.threads, args.recursive)
+    batch_convert_single_to_multi(args.input_path, args.save_path, args.filename_base, args.batch_size, args.threads, args.recursive, args.revert)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added optional retrieval for subset of reads (`-l` / `--limit_by_read_ids`) to `multi_to_single_fast5.py`. Also added `-r` so it can be used instead of `--recursive`. 