### PR TITLE
Update LICENSE.txt URL schemes: http -> https

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 (c) 2017 Oxford Nanopore Technologies Ltd.
 
@@ -347,7 +347,7 @@ notice described in Exhibit B of this License must be attached.
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
-    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE


### PR DESCRIPTION
To start off, thank you so much for releasing the ONT Fast5 specification under the Mozilla Public License.

In this pull request, my humble and minor contribution is to update the license URLs to use the https scheme. In addition to the security benefits, this matches the URL used in the Mozilla Public License itself under Exhibit A - Source Code Form License Notice [1]. 

[1] - [https://www.mozilla.org/en-US/MPL/2.0/](https://www.mozilla.org/en-US/MPL/2.0/)