### PR TITLE
[M]: add tombo resquiggle

### DIFF
--- a/ont_fast5_api/static_data.py
+++ b/ont_fast5_api/static_data.py
@@ -20,6 +20,7 @@ LEGACY_COMPONENT_NAMES = {'Alignment': 'alignment',
                           'Sam_Segmentor': 'sam_segmentor',
                           'arma': 'arma',
                           'Basic_component': 'basic_component',
+                          'RawGenomeCorrected':'raw_genome_corrected' # default name from tombo resquiggle command
                           }
 
 supported_modes = ('r', 'r+', 'w', 'w-', 'x', 'a')


### PR DESCRIPTION
- default component name "RawGenomeCorrected"

Which was widely used in raw signal manipulation.